### PR TITLE
fix: validate postMessage origin before accepting auth token

### DIFF
--- a/src/components/joinButton.vue
+++ b/src/components/joinButton.vue
@@ -2,7 +2,7 @@
 import { ref, reactive, computed, onMounted } from 'vue';
 import { default as eventBus } from '../assets/eventBus';
 import { brightenColor, delay } from '../assets/utilities';
-import { fetchBackend } from '../assets/request';
+import { fetchBackend, API_BASE } from '../assets/request';
 import { TokenUserData, TwitchUser, UserState } from '../types/misc';
 import computePaintStyle from '../assets/applyPaint';
 
@@ -60,6 +60,10 @@ assignUser = async (): Promise<void> => {
 },
 
 handleMessage = (event: MessageEvent) => {
+  if (event.origin !== new URL(API_BASE).origin) {
+    return;
+  }
+
   const { id, login, name, stv_id, token, is_channel } = event.data;
 
   if (!token) {

--- a/src/components/loginButton.vue
+++ b/src/components/loginButton.vue
@@ -90,6 +90,10 @@ const assignUser = async (): Promise<void> => {
 }
 
 const handleMessage = (event: MessageEvent) => {
+  if (event.origin !== new URL(API_BASE).origin) {
+    return;
+  }
+
   const { id, login, name, stv_id, token, is_channel } = event.data;
 
   if (!token) {


### PR DESCRIPTION
i noticed without an `event.origin` check, any page holding a reference to this window could call `postMessage` with a crafted payload and have it stored as a valid auth token in `localStorage`. This fix rejects any message not originating from `API_BASE` so only the actual twitch login popup can deliver credentials