### PR TITLE
fix: remove duplicate signOut listener

### DIFF
--- a/src/components/joinButton.vue
+++ b/src/components/joinButton.vue
@@ -78,10 +78,6 @@ handleMessage = (event: MessageEvent) => {
     user: JSON.stringify({ id, login, name, stv_id, is_channel }),
   });
 
-  eventBus.$on('signOut', () => {
-    signOut();
-  });
-
   userState.value = JSON.stringify({ id, login, name, stv_id, is_channel });
   assignUser();
 


### PR DESCRIPTION
`eventBus.$on('signOut')` was being called inside `handleMessage` stacking a new listener on every sign in. removed it since `onMounted` already registers it once