### PR TITLE
fix: bar alignment in emotes/search

### DIFF
--- a/src/views/emoteSearch.vue
+++ b/src/views/emoteSearch.vue
@@ -217,11 +217,11 @@ onUnmounted(() => {
   display: flex;
   flex-direction: row;
   align-items: center;
-	flex-wrap: wrap;
+  flex-wrap: wrap;
   justify-content: center;
-  max-width: fit-content;
   gap: 10px;
-  margin-bottom: 20px;
+  margin: 0 auto 20px auto;
+  width: fit-content;
   padding: 0.5rem;
   border-radius: 0.5rem;
   background-color: rgba(31, 31, 31, 0.9);


### PR DESCRIPTION
the bar in the [/emotes/search endpoint](https://potat.app/emotes/search) as it was off.

before:
<img width="1903" height="953" alt="image" src="https://github.com/user-attachments/assets/7c065572-d957-46cf-9095-09e6220bfcc1" />

after:
<img width="1903" height="953" alt="image" src="https://github.com/user-attachments/assets/548fbe3d-4dfb-47d7-9464-c338b650612d" />
