### PR TITLE
fix: prevent auth token from being sent to untrusted origins

### DIFF
--- a/src/assets/request.ts
+++ b/src/assets/request.ts
@@ -33,6 +33,12 @@ export async function makeRequest<T = unknown>(
   }
 
   if (options?.auth) {
+    const apiOrigin = new URL(API_BASE).origin;
+    const requestOrigin = new URL(url, window.location.href).origin;
+    if (requestOrigin !== apiOrigin) {
+      throw new Error(`Refusing to send auth token to untrusted origin: ${requestOrigin}`);
+    }
+
     options.headers = {
       'X-Potat-User-Agent': `Potat-Site: ${navigator.userAgent}`,
       ...options.headers,


### PR DESCRIPTION
`makeRequest` would attach the bearer token to any URL when `auth: true` with no checks. added an origin assertion so if the request URL doesnt match `API_BASE`, it throws before the token is ever attached