### PR TITLE
small tweak: updated tools dropdown to align (fixed)

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -231,6 +231,9 @@ img.holiday-emoji {
 }
 .dropdown-content .nav-link {
   display: block;
+  margin-left: 0;
+  width: 100%;
+  box-sizing: border-box;
   margin-right: 0;
   padding: 12px;
   white-space: nowrap;
@@ -243,6 +246,11 @@ img.holiday-emoji {
     display: flex;
     align-items: center;
   }
+
+/* 
+  .nav-link {
+	margin-left: 10px;
+  } */
 
   .more-dropdown .nav-link {
     margin-left: 5px;


### PR DESCRIPTION
before:
<img width="463" height="422" alt="image" src="https://github.com/user-attachments/assets/b3e22f9b-f302-43f6-925d-00159c10df3d" />


after:
<img width="463" height="422" alt="image" src="https://github.com/user-attachments/assets/3b880ef7-dacd-4a9a-b0cc-d539cab98423" />
