### PR TITLE
fix: resolve userState shadowing in connections newToken handler

### DIFF
--- a/src/views/connections.vue
+++ b/src/views/connections.vue
@@ -54,10 +54,9 @@ shakeButton = (platform: string) => {
 };
 
 onMounted(() => {
-  eventBus.$on('newToken', (payload: { token: any; user: any }) => {
-    const userState = JSON.parse(payload.user) ?? {};
+  eventBus.$on('newToken', (payload: { token: string; user: string }) => {
     authorizationToken.value = payload.token;
-    userState.value = userState;
+    userState.value = payload.user;
   })
 })
 </script>


### PR DESCRIPTION
`const userState` inside the `newToken` handler was shadowing the outer reactive ref so the sign in state was never actually being updated. removed the local variable and assign directly to the ref