### PR TITLE
fix: misc bug fixes

### DIFF
--- a/src/components/statsBox.vue
+++ b/src/components/statsBox.vue
@@ -41,7 +41,7 @@ onMounted(async () => {
 			case EventType.PotatoUpdate:
 				for (let i = 0; i < update.updateCount; i++) {
 					data.value.potato.total += 1;
-					await delay(Math.min(5, 5000/update.updateCount));
+					await delay(Math.min(5000 / update.updateCount, 5000));
 				}
 				break;
 		}

--- a/src/views/emoteHistory.vue
+++ b/src/views/emoteHistory.vue
@@ -87,7 +87,7 @@ fetchEmoteHistory = async (pagination?: string | null) => {
 			let expired = null;
 
       if (!update.user_stv_pfp || update.user_stv_pfp === '//cdn.7tv.app/') {
-        update.user_stv_pfp = update.user_pfp;
+        userPfp = update.user_pfp;
       }
 
       if (update.action === 'ALIAS') {
@@ -142,7 +142,7 @@ fetchEmoteHistory = async (pagination?: string | null) => {
 				continue;
 			}
 
-      const key = `${update.emote_id}:${update.ago}:${update.action}:${update.user_login}`
+      const key = `${update.emote_id}:${update.action}:${update.user_login}:${update.set_id}`
       imRetarded.set(key, update);
     }
 

--- a/src/views/emoteSearch.vue
+++ b/src/views/emoteSearch.vue
@@ -189,7 +189,7 @@ onUnmounted(() => {
       <div class="popup-content">
         <img :src="selectedEmote.emoteURL" :alt="selectedEmote.emoteCode"/>
         <h3>{{ selectedEmote.emoteCode }}</h3>
-        <p>Owned By: {{ bestName(selectedEmote.channelName, selectedEmote.channelLogin) }}</p>
+        <p>Owned By: {{ bestName(selectedEmote.channelLogin, selectedEmote.channelName) }}</p>
         <p>Owner ID: {{ selectedEmote.channelID }}</p>
         <p>ID: {{ selectedEmote.emoteID }}</p>
         <p>Format: {{ selectedEmote.emoteAssetType }}</p>
@@ -199,7 +199,7 @@ onUnmounted(() => {
         <p v-if="selectedEmote.bitCost">Bit Cost: {{ selectedEmote.bitCost }}</p>
         <p v-if="selectedEmote.artist">Artist: {{ bestName(selectedEmote.artist.displayName, selectedEmote.artist.login) }}</p>
       </div>
-      <button @click="closePopup" class="close-button">Close</button>
+      <button @click.stop="closePopup" class="close-button">Close</button>
     </div>
   </div>
 </template>


### PR DESCRIPTION
- fixed a dedup key in emoteHistory that used `ago` (a relative time string) two events in the same time bucket would silently overwrite each other. swapped it for a stable combination of `emote_id`, `action`, `user_login` and `set_id`
- `Math.min(5, 5000/updateCount)` in statsBox had the args the wrong way around so the delay was always capped at 5ms. fixed the order
- the close button on the emoteSearch popup was missing `@click.stop` so clicking it would also fire the parent `openChannel` handler and open twitch. added the stop modifier
- `bestName()` in emoteSearch had `channelName` and `channelLogin` passed in the wrong order so it was always returning the wrong value