### PR TITLE
Fix/error handling

### DIFF
--- a/src/assets/socket.ts
+++ b/src/assets/socket.ts
@@ -1,10 +1,12 @@
 /* eslint-disable import/prefer-default-export */
-import { default as eventBus } from '../assets/eventBus';
+import eventBus from './eventBus';
 
 export class StatsSocket {
   private socket: WebSocket | null = null;
 
   private readonly url: string;
+
+  private attempt = 0;
 
   public constructor(url: string) {
     this.url = url;
@@ -15,22 +17,31 @@ export class StatsSocket {
     if (this.socket?.readyState === WebSocket.OPEN) return;
     this.socket = new WebSocket(this.url);
 
-    this.socket.addEventListener('open', () => console.log('Connected to stats server'));
+    this.socket.addEventListener('open', () => {
+      this.attempt = 0;
+    });
 
     this.socket.addEventListener('message', (data: MessageEvent) => {
       try {
         const msg = JSON.parse(data.data);
         eventBus.$emit('update', { data: msg.data, topic: msg.topic.replace('stats/', '') });
       } catch {
-        console.log('Invalid JSON received');
+        // ignore malformed messages
       }
     });
 
+    this.socket.addEventListener('error', () => {
+      // error detail is available in the close event; handled by reconnect
+    });
+
     this.socket.addEventListener('close', () => {
-      console.log('Disconnected from stats server');
       this.reconnect();
     });
   }
 
-  private reconnect() { setTimeout(this.connect.bind(this), 2500); }
+  private reconnect(): void {
+    const delay = Math.min(1000 * 2 ** this.attempt, 30_000);
+    this.attempt += 1;
+    setTimeout(this.connect.bind(this), delay);
+  }
 }

--- a/src/components/joinButton.vue
+++ b/src/components/joinButton.vue
@@ -25,7 +25,7 @@ newState = reactive<{ value: boolean }>({
 }),
 
 isAuthenticated = computed<boolean>(() => {
-  return authorizationToken.value !== null || userState.value !== null;
+  return authorizationToken.value !== null && userState.value !== null;
 }),
 
 isChannel = computed<boolean>(() => {

--- a/src/components/statsBox.vue
+++ b/src/components/statsBox.vue
@@ -16,8 +16,16 @@ enum EventType {
 
 
 const data: Ref = ref({});
+const fetchError = ref(false);
 onMounted(async () => {
-	data.value = await fetchBackend('').then(res => res?.data?.[0])
+	try {
+		const res = await fetchBackend('');
+		data.value = res?.data?.[0];
+		if (!data.value) fetchError.value = true;
+	} catch (err) {
+		console.error('[statsBox] Failed to fetch stats:', err);
+		fetchError.value = true;
+	}
 
 	eventBus.$on('update', async (stats) => {
 		const { data: update, topic } = stats as UpdateEvent;
@@ -50,7 +58,8 @@ onMounted(async () => {
 </script>
 
 <template>
-  <div v-if="data.misc" class="text-container">
+  <div v-if="fetchError" class="text-container error-state">Failed to load stats.</div>
+  <div v-else-if="data.misc" class="text-container">
 		<strong>Commands used:</strong>
 		<span>{{ data?.misc?.commandsUsed?.toLocaleString() }}</span>
 
@@ -93,4 +102,9 @@ onMounted(async () => {
 	}
 }
 
+.error-state {
+	display: block;
+	color: #f87171;
+	font-size: 0.9em;
+}
 </style>

--- a/src/views/emoteSearch.vue
+++ b/src/views/emoteSearch.vue
@@ -16,6 +16,7 @@ emotes = ref<Emote[]>([]),
 isRequesting = ref(false),
 selectedEmote = ref<EmoteInfo | null>(null),
 isLoading = ref(false),
+searchError = ref<string | null>(null),
 searchEmotes = async (query: string, options: SearchOptions): Promise<Emote[]> => {
   if (isRequesting.value) return [];
 
@@ -35,6 +36,7 @@ searchEmotes = async (query: string, options: SearchOptions): Promise<Emote[]> =
 
   if (response.errors?.length) {
     console.error(response.errors);
+    searchError.value = response.errors[0]?.message ?? 'Search failed. Please try again.';
     return [];
   }
 
@@ -73,6 +75,7 @@ onQuery = async () => {
 onNewQuery = async () => {
   emotes.value = [];
   cursor.value = null;
+  searchError.value = null;
   onQuery();
 },
 
@@ -149,6 +152,7 @@ onUnmounted(() => {
 
 <template>
   <div class="container">
+    <div v-if="searchError" class="search-error" role="alert">{{ searchError }}</div>
     <div class="search-bar">
       <input
         type="text"
@@ -310,5 +314,12 @@ onUnmounted(() => {
 
 .close-button:hover {
   background-color: rgba(255, 255, 255, 0.5);
+}
+
+.search-error {
+  color: #f87171;
+  margin-bottom: 12px;
+  font-size: 0.9em;
+  text-align: center;
 }
 </style>


### PR DESCRIPTION
- **socket.ts**: add exponential backoff on reconnect (caps at 30s); add `error` event listener; fix import path
- **statsBox.vue**: wrap initial fetch in try/catch; show error message to user on failure instead of silently rendering nothing
- **emoteSearch.vue**: surface API errors to the user via an alert banner instead of only logging to console
- **joinButton.vue**: fix `isAuthenticated` using `||` instead of `&&` - both token and userState must be present